### PR TITLE
Loom 2.4.1: bug fixes

### DIFF
--- a/yarns/multi.h
+++ b/yarns/multi.h
@@ -208,7 +208,7 @@ class Multi {
   ) const {
     if ( // Stop NoteOn, but NoteOff must go through for the latch to 'mature'
       midi(part).sustain_mode == SUSTAIN_MODE_FILTER &&
-      part_[part].PressedKeysForLatchUI().ignore_note_off_messages
+      part_[part].PressedKeysForLatchUI().all_sustainable
     ) {
       return false;
     }

--- a/yarns/multi.h
+++ b/yarns/multi.h
@@ -206,9 +206,11 @@ class Multi {
   inline bool part_accepts_note_on(
     uint8_t part, uint8_t channel, uint8_t note, uint8_t velocity
   ) const {
-    if ( // Stop NoteOn, but NoteOff must go through for the latch to 'mature'
+    // Block NoteOn, but allow NoteOff so the key can transition from
+    // sustainable to sustained
+    if (
       midi(part).sustain_mode == SUSTAIN_MODE_FILTER &&
-      part_[part].PressedKeysForLatchUI().all_sustainable
+      part_[part].HeldKeysForUI().universally_sustainable
     ) {
       return false;
     }

--- a/yarns/oscillator.cc
+++ b/yarns/oscillator.cc
@@ -182,7 +182,7 @@ void Oscillator::Render() {
     phase += phase_increment; \
     timbre_.Tick(); gain_.Tick(); \
     body \
-    audio_buffer_.Overwrite(offset_ + ((gain_.value() * this_sample) >> 15)); \
+    audio_buffer_.Overwrite((gain_.value() * this_sample) >> 15); \
   } \
   next_sample_ = next_sample; \
   phase_ = phase; \

--- a/yarns/oscillator.h
+++ b/yarns/oscillator.h
@@ -91,10 +91,9 @@ class Oscillator {
   Oscillator() { }
   ~Oscillator() { }
 
-  inline void Init(uint16_t scale, uint16_t offset) {
+  inline void Init(uint16_t scale) {
     audio_buffer_.Init();
     scale_ = scale;
-    offset_ = offset;
     timbre_.Init(64);
     gain_.Init(64);
     svf_.Init(64);
@@ -163,7 +162,7 @@ class Oscillator {
   PhaseDistortionSquareModulator pd_square_;
   
   int32_t next_sample_;
-  uint16_t scale_, offset_;
+  uint16_t scale_;
   stmlib::RingBuffer<uint16_t, kAudioBlockSize * 2> audio_buffer_;
   
   static RenderFn fn_table_[];

--- a/yarns/part.cc
+++ b/yarns/part.cc
@@ -136,17 +136,17 @@ void Part::AllocateVoices(Voice* voice, uint8_t num_voices, bool polychain) {
   TouchVoices();
 }
 
-uint8_t Part::PressedKeysNoteOn(PressedKeys &keys, uint8_t pitch, uint8_t velocity) {
+uint8_t Part::HeldKeysNoteOn(HeldKeys &keys, uint8_t pitch, uint8_t velocity) {
   if (keys.stop_sustained_notes_on_next_note_on) {
-    bool still_latched = keys.all_sustainable;
+    bool still_latched = keys.universally_sustainable;
 
     // Releasing all latched key will generate "fake" NoteOff messages. We
     // should not ignore them.
-    keys.all_sustainable = false;
+    keys.universally_sustainable = false;
     StopSustainedNotes(keys);
 
     keys.stop_sustained_notes_on_next_note_on = still_latched;
-    keys.all_sustainable = still_latched;
+    keys.universally_sustainable = still_latched;
   }
   bool sustained = keys.IsSustained(pitch); // Capture existing sustain status
   uint8_t index = keys.stack.NoteOn(pitch, velocity);
@@ -166,13 +166,13 @@ bool Part::NoteOn(uint8_t channel, uint8_t note, uint8_t velocity) {
     if (!looped() && !sent_from_step_editor) {
       RecordStep(SequencerStep(note, velocity));
     } else if (looped()) {
-      uint8_t pressed_key_index = PressedKeysNoteOn(manual_keys_, note, velocity);
+      uint8_t pressed_key_index = HeldKeysNoteOn(manual_keys_, note, velocity);
       LooperRecordNoteOn(pressed_key_index);
     }
   } else if (midi_.play_mode == PLAY_MODE_ARPEGGIATOR) {
-    PressedKeysNoteOn(arp_keys_, note, velocity);
+    HeldKeysNoteOn(arp_keys_, note, velocity);
   } else {
-    PressedKeysNoteOn(manual_keys_, note, velocity);
+    HeldKeysNoteOn(manual_keys_, note, velocity);
     if (sent_from_step_editor || manual_control()) {
       InternalNoteOn(note, velocity);
     }
@@ -205,18 +205,18 @@ bool Part::NoteOff(uint8_t channel, uint8_t note) {
   return midi_.out_mode == MIDI_OUT_MODE_THRU && !polychained_;
 }
 
-void Part::PressedKeysSustainOn(PressedKeys &keys) {
+void Part::HeldKeysSustainOn(HeldKeys &keys) {
   switch (midi_.sustain_mode) {
     case SUSTAIN_MODE_NORMAL:
-      keys.all_sustainable = true;
+      keys.universally_sustainable = true;
       break;
     case SUSTAIN_MODE_SOSTENUTO:
-      keys.SetSustainable(true);
+      keys.SetIndividuallySustainable(true);
       break;
     case SUSTAIN_MODE_LATCH:
     case SUSTAIN_MODE_MOMENTARY_LATCH:
     case SUSTAIN_MODE_FILTER:
-      keys.all_sustainable = true;
+      keys.universally_sustainable = true;
       keys.stop_sustained_notes_on_next_note_on = true;
       break;
     case SUSTAIN_MODE_CLUTCH:
@@ -228,23 +228,23 @@ void Part::PressedKeysSustainOn(PressedKeys &keys) {
   }
 }
 
-void Part::PressedKeysSustainOff(PressedKeys &keys) {
+void Part::HeldKeysSustainOff(HeldKeys &keys) {
   switch (midi_.sustain_mode) {
     case SUSTAIN_MODE_NORMAL:
-      keys.all_sustainable = false;
+      keys.universally_sustainable = false;
       StopSustainedNotes(keys);
       break;
     case SUSTAIN_MODE_SOSTENUTO:
-      keys.SetSustainable(false);
+      keys.SetIndividuallySustainable(false);
       StopSustainedNotes(keys);
       break;
     case SUSTAIN_MODE_LATCH:
     case SUSTAIN_MODE_FILTER:
-      keys.all_sustainable = false;
+      keys.universally_sustainable = false;
       keys.stop_sustained_notes_on_next_note_on = true;
       break;
     case SUSTAIN_MODE_MOMENTARY_LATCH:
-      PressedKeysResetLatch(keys);
+      ResetKeys(keys);
     case SUSTAIN_MODE_CLUTCH:
       keys.Clutch(true);
       break;
@@ -254,9 +254,9 @@ void Part::PressedKeysSustainOff(PressedKeys &keys) {
   }
 }
 
-void Part::ResetLatch() {
-  PressedKeysResetLatch(manual_keys_);
-  PressedKeysResetLatch(arp_keys_);
+void Part::ResetAllKeys() {
+  ResetKeys(manual_keys_);
+  ResetKeys(arp_keys_);
   ControlChange(0, kCCHoldPedal, hold_pedal_engaged_ ? 127 : 0);
 }
 
@@ -742,7 +742,7 @@ const ArpeggiatorState Part::BuildArpState(SequencerStep* seq_step_ptr) const {
 }
 
 void Part::ResetAllControllers() {
-  ResetLatch();
+  ResetAllKeys();
   for (uint8_t i = 0; i < num_voices_; ++i) {
     voice_[i]->ResetAllControllers();
   }
@@ -752,7 +752,7 @@ void Part::AllNotesOff() {
   poly_allocator_.ClearNotes();
   mono_allocator_.Clear();
 
-  ResetLatch();
+  ResetAllKeys();
 
   generated_notes_.Clear();
   looper_note_index_for_generated_note_index_[generated_notes_.most_recent_note_index()] = looper::kNullIndex;
@@ -765,11 +765,11 @@ void Part::AllNotesOff() {
       VOICE_ALLOCATION_NOT_FOUND);
 }
 
-void Part::StopNotesBySustainStatus(PressedKeys &keys, bool sustain_status) {
+void Part::StopNotesBySustainStatus(HeldKeys &keys, bool sustain_status) {
   for (uint8_t i = 1; i <= keys.stack.max_size(); ++i) {
     NoteEntry* e = keys.stack.mutable_note(i);
     if (keys.IsSustained(*e) != sustain_status) continue;
-    e->velocity &= ~PressedKeys::VELOCITY_SUSTAIN_MASK; // Un-flag the note
+    e->velocity &= ~HeldKeys::VELOCITY_SUSTAIN_MASK; // Un-flag the note
     NoteOff(tx_channel(), e->note);
   }
 }

--- a/yarns/part.h
+++ b/yarns/part.h
@@ -619,6 +619,7 @@ struct PressedKeys {
     );
   }
 
+  // Returns true if result is NoteOff
   bool SustainableNoteOff(uint8_t pitch) {
     SetSustain(pitch);
     if (IsSustained(pitch)) { return false; }
@@ -631,18 +632,6 @@ struct PressedKeys {
     if (!i || !IsSustainable(i)) { return; }
     // Flag the note so that it is removed once the sustain pedal is released.
     stack.mutable_note(i)->velocity |= VELOCITY_SUSTAIN_MASK;
-  }
-
-  bool SustainAll() {
-    bool changed = false;
-    for (uint8_t i = 1; i <= stack.max_size(); ++i) {
-      stmlib::NoteEntry* e = stack.mutable_note(i);
-      if (e->note == stmlib::NOTE_STACK_FREE_SLOT) { continue; }
-      if (IsSustained(*e)) { continue; }
-      e->velocity |= VELOCITY_SUSTAIN_MASK;
-      changed = true;
-    }
-    return changed;
   }
 
   void SetSustainable(bool value) {
@@ -1025,7 +1014,10 @@ class Part {
   void TouchVoiceAllocation();
   void TouchVoices();
   
-  void ReleaseLatchedNotes(PressedKeys &keys);
+  void ReleaseNotesBySustainStatus(PressedKeys &keys, bool where_sustained);
+  void ReleaseLatchedNotes(PressedKeys &keys) {
+    ReleaseNotesBySustainStatus(keys, true);
+  }
   void DispatchSortedNotes(bool legato);
   void VoiceNoteOn(Voice* voice, uint8_t pitch, uint8_t vel, bool legato);
   void KillAllInstancesOfNote(uint8_t note);

--- a/yarns/part.h
+++ b/yarns/part.h
@@ -620,7 +620,7 @@ struct HeldKeys {
   }
 
   // Returns true if result is NoteOff
-  bool NoteOff(uint8_t pitch, bool respect_sustain = true) {
+  bool NoteOff(uint8_t pitch, bool respect_sustain) {
     if (respect_sustain) {
       SetSustain(pitch);
       if (IsSustained(pitch)) return false;

--- a/yarns/part.h
+++ b/yarns/part.h
@@ -620,9 +620,11 @@ struct HeldKeys {
   }
 
   // Returns true if result is NoteOff
-  bool SustainableNoteOff(uint8_t pitch) {
-    SetSustain(pitch);
-    if (IsSustained(pitch)) { return false; }
+  bool NoteOff(uint8_t pitch, bool respect_sustain = true) {
+    if (respect_sustain) {
+      SetSustain(pitch);
+      if (IsSustained(pitch)) return false;
+    }
     stack.NoteOff(pitch);
     return true;
   }
@@ -641,9 +643,14 @@ struct HeldKeys {
     }
   }
 
-  void Clutch(bool not_pedal_engaged) {
-    stop_sustained_notes_on_next_note_on = not_pedal_engaged;
-    SetIndividuallySustainable(!not_pedal_engaged);
+  void Clutch(bool sustain_on) {
+    stop_sustained_notes_on_next_note_on = !sustain_on;
+    SetIndividuallySustainable(sustain_on);
+  }
+
+  void Latch(bool sustain_on) {
+    universally_sustainable = sustain_on;
+    stop_sustained_notes_on_next_note_on = true;
   }
 
   bool IsSustainable(uint8_t index) const {
@@ -678,7 +685,7 @@ class Part {
   // whether the message should be sent to the part.
   uint8_t HeldKeysNoteOn(HeldKeys &keys, uint8_t pitch, uint8_t velocity);
   bool NoteOn(uint8_t channel, uint8_t note, uint8_t velocity);
-  bool NoteOff(uint8_t channel, uint8_t note);
+  bool NoteOff(uint8_t channel, uint8_t note, bool respect_sustain = true);
   uint8_t TransposeInputPitch(uint8_t pitch, int8_t transpose_octaves) const {
     CONSTRAIN(transpose_octaves, (0 - pitch) / 12, (127 - pitch) / 12);
     return pitch + 12 * transpose_octaves;

--- a/yarns/part.h
+++ b/yarns/part.h
@@ -599,22 +599,22 @@ struct ArpeggiatorState {
   }
 };
 
-struct PressedKeys {
+struct HeldKeys {
 
   static const uint8_t VELOCITY_SUSTAIN_MASK = 0x80;
 
   stmlib::NoteStack<kNoteStackSize> stack;
-  bool all_sustainable;
+  bool universally_sustainable; // Includes keys not yet pressed
   bool stop_sustained_notes_on_next_note_on;
-  bool sustainable[kNoteStackMapping];
+  bool individually_sustainable[kNoteStackMapping]; // Only keys already held
 
   void Init() {
     stack.Init();
-    all_sustainable = false;
+    universally_sustainable = false;
     stop_sustained_notes_on_next_note_on = false;
     std::fill(
-      &sustainable[0],
-      &sustainable[kNoteStackMapping],
+      &individually_sustainable[0],
+      &individually_sustainable[kNoteStackMapping],
       false
     );
   }
@@ -634,20 +634,20 @@ struct PressedKeys {
     stack.mutable_note(i)->velocity |= VELOCITY_SUSTAIN_MASK;
   }
 
-  void SetSustainable(bool value) {
+  void SetIndividuallySustainable(bool value) {
     for (uint8_t i = 1; i <= stack.max_size(); ++i) {
       if (stack.note(i).note == stmlib::NOTE_STACK_FREE_SLOT) { continue; }
-      sustainable[i - 1] = value;
+      individually_sustainable[i - 1] = value;
     }
   }
 
-  void Clutch(bool on) {
-    stop_sustained_notes_on_next_note_on = on;
-    SetSustainable(!on);
+  void Clutch(bool not_pedal_engaged) {
+    stop_sustained_notes_on_next_note_on = not_pedal_engaged;
+    SetIndividuallySustainable(!not_pedal_engaged);
   }
 
   bool IsSustainable(uint8_t index) const {
-    return all_sustainable || sustainable[index - 1];
+    return universally_sustainable || individually_sustainable[index - 1];
   }
 
   bool IsSustained(const stmlib::NoteEntry &note_entry) const {
@@ -676,7 +676,7 @@ class Part {
   // Also, note that channel / keyrange / velocity range filtering is not
   // applied here. It is up to the caller to call accepts() first to check
   // whether the message should be sent to the part.
-  uint8_t PressedKeysNoteOn(PressedKeys &keys, uint8_t pitch, uint8_t velocity);
+  uint8_t HeldKeysNoteOn(HeldKeys &keys, uint8_t pitch, uint8_t velocity);
   bool NoteOn(uint8_t channel, uint8_t note, uint8_t velocity);
   bool NoteOff(uint8_t channel, uint8_t note);
   uint8_t TransposeInputPitch(uint8_t pitch, int8_t transpose_octaves) const {
@@ -838,26 +838,26 @@ class Part {
   void DeleteRecording();
 
   inline void SustainOn() {
-    PressedKeysSustainOn(manual_keys_);
-    PressedKeysSustainOn(arp_keys_);
+    HeldKeysSustainOn(manual_keys_);
+    HeldKeysSustainOn(arp_keys_);
   }
   inline void SustainOff() {
-    PressedKeysSustainOff(manual_keys_);
-    PressedKeysSustainOff(arp_keys_);
+    HeldKeysSustainOff(manual_keys_);
+    HeldKeysSustainOff(arp_keys_);
   }
-  void PressedKeysSustainOn(PressedKeys &keys);
-  void PressedKeysSustainOff(PressedKeys &keys);
-  inline const PressedKeys& PressedKeysForLatchUI() const {
+  void HeldKeysSustainOn(HeldKeys &keys);
+  void HeldKeysSustainOff(HeldKeys &keys);
+  inline const HeldKeys& HeldKeysForUI() const {
     return midi_.play_mode == PLAY_MODE_ARPEGGIATOR ? arp_keys_ : manual_keys_;
   }
-  inline PressedKeys& MutablePressedKeysForLatchUI() {
+  inline HeldKeys& MutableHeldKeysForUI() {
     return midi_.play_mode == PLAY_MODE_ARPEGGIATOR ? arp_keys_ : manual_keys_;
   }
-  inline void PressedKeysResetLatch(PressedKeys &keys) {
+  inline void ResetKeys(HeldKeys &keys) {
     StopSustainedNotes(keys);
     keys.Init();
   }
-  void ResetLatch();
+  void ResetAllKeys();
 
   inline uint8_t ArpUndoTransposeInputPitch(uint8_t pitch) const {
     if (midi_.play_mode == PLAY_MODE_ARPEGGIATOR && pitch < SEQUENCER_STEP_REST) {
@@ -1001,7 +1001,7 @@ class Part {
     AllNotesOff();
     TouchVoices();
     TouchVoiceAllocation();
-    ResetLatch();
+    ResetAllKeys();
   }
 
   void set_siblings(bool has_siblings) {
@@ -1014,8 +1014,8 @@ class Part {
   void TouchVoiceAllocation();
   void TouchVoices();
   
-  void StopNotesBySustainStatus(PressedKeys &keys, bool where_sustained);
-  void StopSustainedNotes(PressedKeys &keys) {
+  void StopNotesBySustainStatus(HeldKeys &keys, bool where_sustained);
+  void StopSustainedNotes(HeldKeys &keys) {
     StopNotesBySustainStatus(keys, true);
   }
   void DispatchSortedNotes(bool legato);
@@ -1035,8 +1035,8 @@ class Part {
   uint8_t num_voices_;
   bool polychained_;
 
-  PressedKeys manual_keys_;
-  PressedKeys arp_keys_;
+  HeldKeys manual_keys_;
+  HeldKeys arp_keys_;
   bool hold_pedal_engaged_;
 
   stmlib::NoteStack<kNoteStackSize> generated_notes_;  // by sequencer or arpeggiator.

--- a/yarns/ui.cc
+++ b/yarns/ui.cc
@@ -1046,7 +1046,7 @@ void Ui::PrintLatch() {
     bool sustained = keys.IsSustained(note_entry);
     bool top;
     if (sustained) {
-      top = (keys.stop_sustained_notes_on_next_note_on && !keys.universally_sustainable) ? blink : true;
+      top = keys.stop_sustained_notes_on_next_note_on ? blink : true;
     } else {
       top = keys.IsSustainable(note_index);
     }

--- a/yarns/ui.cc
+++ b/yarns/ui.cc
@@ -46,7 +46,7 @@ const uint16_t kRefreshTwoThirds = 600;
 const uint32_t kEncoderLongPressTime = kRefreshPeriod * 2 / 3;
 const uint32_t kDefaultFade = (1 << 15) / kRefreshPeriod; // 1/2 frequency
 
-const char* const kVersion = "Loom 2_4_0";
+const char* const kVersion = "Loom 2_4_1";
 
 /* static */
 const Ui::Command Ui::commands_[] = {

--- a/yarns/ui.cc
+++ b/yarns/ui.cc
@@ -752,8 +752,8 @@ void Ui::OnSwitchPress(const Event& e) {
   }
 }
 
-PressedKeys& Ui::LatchableKeys() {
-  return mutable_active_part()->MutablePressedKeysForLatchUI();
+HeldKeys& Ui::ActivePartHeldKeys() {
+  return mutable_active_part()->MutableHeldKeysForUI();
 }
 
 void Ui::OnSwitchHeld(const Event& e) {
@@ -765,11 +765,11 @@ void Ui::OnSwitchHeld(const Event& e) {
         mutable_recording_part()->DeleteRecording();
         SplashOn(SPLASH_DELETE_RECORDING, active_part_);
       } else {
-        PressedKeys &keys = LatchableKeys();
-        if (keys.all_sustainable) {
-          mutable_active_part()->PressedKeysSustainOff(keys);
+        HeldKeys &keys = ActivePartHeldKeys();
+        if (keys.universally_sustainable) {
+          mutable_active_part()->HeldKeysSustainOff(keys);
         } else if (multi.running() && keys.stack.most_recent_note_index()) {
-          mutable_active_part()->PressedKeysSustainOn(keys);
+          mutable_active_part()->HeldKeysSustainOn(keys);
         } else {
           if (push_it_) {
             multi.PushItNoteOff(push_it_note_);
@@ -986,7 +986,7 @@ void Ui::DoEvents() {
   // If display is idle, flash various statuses
   bool print_latch =
     active_part().midi_settings().sustain_mode != SUSTAIN_MODE_OFF &&
-    LatchableKeys().stack.most_recent_note_index();
+    ActivePartHeldKeys().stack.most_recent_note_index();
   bool print_part = mode_ == UI_MODE_PARAMETER_SELECT;
   if (queue_.idle_time() > kRefreshTwoThirds) {
     if (print_part) {
@@ -1031,7 +1031,7 @@ const uint16_t kHoldDisplayMasks[2][3] = {
 };
 void Ui::PrintLatch() {
   display_.set_fade(0);
-  const PressedKeys& keys = LatchableKeys();
+  const HeldKeys& keys = ActivePartHeldKeys();
   uint16_t masks[kDisplayWidth];
   std::fill(&masks[0], &masks[kDisplayWidth], 0);
   uint8_t note_ordinal = 0, display_pos = 0;
@@ -1046,7 +1046,7 @@ void Ui::PrintLatch() {
     bool sustained = keys.IsSustained(note_entry);
     bool top;
     if (sustained) {
-      top = (keys.stop_sustained_notes_on_next_note_on && !keys.all_sustainable) ? blink : true;
+      top = (keys.stop_sustained_notes_on_next_note_on && !keys.universally_sustainable) ? blink : true;
     } else {
       top = keys.IsSustainable(note_index);
     }

--- a/yarns/ui.cc
+++ b/yarns/ui.cc
@@ -766,7 +766,7 @@ void Ui::OnSwitchHeld(const Event& e) {
         SplashOn(SPLASH_DELETE_RECORDING, active_part_);
       } else {
         PressedKeys &keys = LatchableKeys();
-        if (keys.ignore_note_off_messages) {
+        if (keys.all_sustainable) {
           mutable_active_part()->PressedKeysSustainOff(keys);
         } else if (multi.running() && keys.stack.most_recent_note_index()) {
           mutable_active_part()->PressedKeysSustainOn(keys);
@@ -1046,7 +1046,7 @@ void Ui::PrintLatch() {
     bool sustained = keys.IsSustained(note_entry);
     bool top;
     if (sustained) {
-      top = (keys.release_latched_keys_on_next_note_on && !keys.ignore_note_off_messages) ? blink : true;
+      top = (keys.stop_sustained_notes_on_next_note_on && !keys.all_sustainable) ? blink : true;
     } else {
       top = keys.IsSustainable(note_index);
     }

--- a/yarns/ui.h
+++ b/yarns/ui.h
@@ -232,7 +232,7 @@ class Ui {
   void PrintLatch();
   void SetFadeForSetting(const Setting& setting);
 
-  PressedKeys& LatchableKeys();
+  HeldKeys& ActivePartHeldKeys();
   
   void StopRecording();
 

--- a/yarns/voice.h
+++ b/yarns/voice.h
@@ -303,12 +303,12 @@ class CVOutput {
     dc_voice_->set_dc_output(dc_role, this);
 
     num_audio_voices_ = num_audio;
-    uint16_t offset = volts_dac_code(0);
+    zero_dac_code_ = volts_dac_code(0);
     uint16_t scale = volts_dac_code(0) - volts_dac_code(5); // 5Vpp
     scale /= num_audio_voices_;
     for (uint8_t i = 0; i < num_audio_voices_; ++i) {
       Voice* audio_voice = audio_voices_[i] = dc_voice_ + i;
-      audio_voice->oscillator()->Init(scale, offset);
+      audio_voice->oscillator()->Init(scale);
       audio_voice->set_audio_output(this);
     }
   }
@@ -335,9 +335,9 @@ class CVOutput {
   }
 
   inline uint16_t GetAudioSample() {
-    uint16_t mix = 0;
+    uint16_t mix = zero_dac_code_;
     for (uint8_t i = 0; i < num_audio_voices_; ++i) {
-      mix += audio_voices_[i]->ReadSample();
+      mix -= audio_voices_[i]->ReadSample();
     }
     return mix;
   }
@@ -414,6 +414,7 @@ class CVOutput {
   int32_t note_;
   uint16_t note_dac_code_;
   bool dirty_;  // Set to true when the calibration settings have changed.
+  uint16_t zero_dac_code_;
   uint16_t calibrated_dac_code_[kNumOctaves];
   Interpolator dac_interpolator_;
 


### PR DESCRIPTION
- [Remove DC offset from paraphonic audio](https://github.com/rcrogers/yarns-loom/pull/32/commits/5ba7aa2345b52f0e02caa33fa9385613c3f7cb67)
- [The logic for preventing stuck notes when changing the `INPUT TRANSPOSE OCTAVES` setting now only stops notes that are manually held, sparing notes that are sustained or sequencer-generated](https://github.com/rcrogers/yarns-loom/pull/32/commits/0e173262995fa06abb270bec15b5d9208ca8311c) 
- [Fix `MOMENTARY LATCH` failing to stop notes](https://github.com/rcrogers/yarns-loom/pull/32/commits/c72337d53c40ee3b1622d857fe058c404d70b395) 
- [Fix `LATCH` to correctly display when a key-press will cause sustained notes to be stopped](https://github.com/rcrogers/yarns-loom/pull/32/commits/c72337d53c40ee3b1622d857fe058c404d70b395)